### PR TITLE
make filter search anywhere in Component name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/src/client/src/components/element/SearchComponentName.js
+++ b/src/client/src/components/element/SearchComponentName.js
@@ -158,7 +158,7 @@ class SearchComponentName extends Component {
                                 minLength={1}
                                 value={this.state.value}
                                 onChange={this.handleChange}
-                                filter={'startsWith'}
+                                filter={'contains'}
                                 onSelect={this.handleSelect}/>
                         </div>
 

--- a/src/client/src/components/panel/PanelAvailableComponents.js
+++ b/src/client/src/components/panel/PanelAvailableComponents.js
@@ -82,7 +82,7 @@ class PanelAvailableComponents extends Component {
                 let components = [];
                 _.forOwn(group, (componentTypeValue, componentName) => {
                     if(_filter){
-                        if(componentName.toUpperCase().startsWith(_filter)){
+                        if(componentName.toUpperCase().includes(_filter)){
                             components.push(
                                 <PanelAvailableComponentItem
                                     key={'item' + componentName + counter}


### PR DESCRIPTION
Fixes https://github.com/ipselon/structor/issues/30

also add .gitignore for npm things. Could possibly also add static/server directories to this?

Pros:
- Easier to explore/view available components in filtered list

Cons: 
- typing the start of component name doesn't necessarily select that component (e.g. Typing "butto" in Material prepack and button is last)

